### PR TITLE
Fix 3b6ed3cfb2f2c970fb: keep old Bisonc++/Flexc++ code.

### DIFF
--- a/checktestdata.l
+++ b/checktestdata.l
@@ -65,14 +65,22 @@ SCIENTIFIC { return Parser::OPT_SCIENTIFIC; }
 
 \" {
 	/* begin of string */
+#if ( FLEXCPP_VERSION >= 20700LL )
 	begin(StartCondition_::string);
+#else
+	begin(StartCondition__::string);
+#endif
 }
 
 <string>{
 \" {
 	/* end of string */
 	setMatched(matched().substr(0,matched().length()-1));
+#if ( FLEXCPP_VERSION >= 20700LL )
 	begin(StartCondition_::INITIAL);
+#else
+	begin(StartCondition__::INITIAL);
+#endif
 	return Parser::STRING;
 }
 

--- a/parser.h
+++ b/parser.h
@@ -32,18 +32,34 @@ class Parser: public ParserBase
         parse_t parseResult;
 
     private:
+#if ( BISONCPP_VERSION >= 60000LL )
         void error();                   // called on (syntax) errors
+#else
+        void error(char const *msg);
+#endif
         int lex();                      // returns the next token from the
                                         // lexical scanner.
         void print();                   // use, e.g., d_token, d_loc
+#if ( BISONCPP_VERSION >= 60000LL )
         void exceptionHandler(std::exception const &exc);
+#else
+        void exceptionHandler__(std::exception const &exc);
+#endif
 
     // support functions for parse():
+#if ( BISONCPP_VERSION >= 60000LL )
         void executeAction_(int ruleNr);
         void errorRecovery_();
         void nextCycle_();
         void nextToken_();
         void print_();
+#else
+        void executeAction(int ruleNr);
+        void errorRecovery();
+        int lookup(bool recovery);
+        void nextToken();
+        void print__();
+#endif
 };
 
 

--- a/parser.ih
+++ b/parser.ih
@@ -6,16 +6,24 @@
 #include "parser.h"
 
 
+#if ( BISONCPP_VERSION >= 60000LL )
 inline void Parser::error()
+#else
+inline void Parser::error(char const *msg)
+#endif
 {
-    std::cerr << "Syntax error\n";
+    std::cerr << "Syntax error on line " << d_scanner.lineNr() << std::endl;
 }
 
 // $insert lex
 inline int Parser::lex()
 {
 	int res = d_scanner.lex();
+#if ( BISONCPP_VERSION >= 60000LL )
 	d_val_ = STYPE_(d_scanner.matched());
+#else
+	d_val__ = STYPE__(d_scanner.matched());
+#endif
 	return res;
 }
 
@@ -23,10 +31,12 @@ inline void Parser::print()
 {
 }
 
+#if ( BISONCPP_VERSION < 60000LL )
 inline void Parser::exceptionHandler(std::exception const &exc)
 {
     throw;              // re-implement to handle exceptions thrown by actions
 }
+#endif
 
 
     // Add here includes that are only required for the compilation

--- a/parser.ih
+++ b/parser.ih
@@ -32,7 +32,7 @@ inline void Parser::print()
 }
 
 #if ( BISONCPP_VERSION < 60000LL )
-inline void Parser::exceptionHandler(std::exception const &exc)
+inline void Parser::exceptionHandler__(std::exception const &exc)
 {
     throw;              // re-implement to handle exceptions thrown by actions
 }

--- a/scanner.h
+++ b/scanner.h
@@ -88,7 +88,11 @@ inline void Scanner::preCode()
     // optionally replace by your own code
 }
 
+#if ( FLEXCPP_VERSION >= 20700LL )
 inline void Scanner::postCode(PostEnum_ type)
+#else
+inline void Scanner::postCode(PostEnum__ type)
+#endif
 {
     // optionally replace by your own code
 }

--- a/scanner.h
+++ b/scanner.h
@@ -36,14 +36,23 @@ class Scanner: public ScannerBase
         int lex();
 
     private:
+#if ( FLEXCPP_VERSION >= 20700LL )
         int lex_();
         int executeAction_(size_t ruleNr);
+#else
+        int lex__();
+        int executeAction__(size_t ruleNr);
+#endif
 
         void print();
         void preCode();     // re-implement this function for code that must
                             // be exec'ed before the patternmatching starts
 
+#if ( FLEXCPP_VERSION >= 20700LL )
         void postCode(PostEnum_ type);
+#else
+        void postCode(PostEnum__ type);
+#endif
                             // re-implement this function for code that must
                             // be exec'ed after the rules's actions.
 };
@@ -67,7 +76,11 @@ inline int Scanner::lex()
 		parserStart = 0;
 		return res;
 	}
+#if ( FLEXCPP_VERSION >= 20700LL )
     return lex_();
+#else
+    return lex__();
+#endif
 }
 
 inline void Scanner::preCode()
@@ -75,14 +88,18 @@ inline void Scanner::preCode()
     // optionally replace by your own code
 }
 
-inline void Scanner::postCode([[maybe_unused]] PostEnum_ type)
+inline void Scanner::postCode(PostEnum_ type)
 {
     // optionally replace by your own code
 }
 
 inline void Scanner::print()
 {
+#if ( FLEXCPP_VERSION >= 20700LL )
     print_();
+#else
+    print__();
+#endif
 }
 
 


### PR DESCRIPTION
Also drop a C++17 [[maybe_unused]] attribute that generates a
compiler error on some old compilers (GCC 4.8.4 on Travis CI).